### PR TITLE
73 bug passphrase separators have incorrect values

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ PW_INCLUDE_SPECIAL = os.getenv('PW_INCLUDE_SPECIAL', 'true').lower() == 'true'
 PW_EXCLUDE_HOMOGLYPHS = os.getenv('PW_EXCLUDE_HOMOGLYPHS', 'false').lower() == 'true'
 PP_WORD_COUNT = int(os.getenv('PP_WORD_COUNT', '4'))
 PP_CAPITALIZE = os.getenv('PP_CAPITALIZE', 'false').lower() == 'true'
-PP_SEPARATOR_TYPE = os.getenv('PP_SEPARATOR_TYPE', 'space')
+PP_SEPARATOR_TYPE = os.getenv('PP_SEPARATOR_TYPE', 'dash')
 PP_USER_DEFINED_SEPARATOR = os.getenv('PP_USER_DEFINED_SEPARATOR', '')
 PP_MAX_WORD_LENGTH = int(os.getenv('PP_MAX_WORD_LENGTH', '7'))
 PP_INCLUDE_NUMBERS = os.getenv('PP_INCLUDE_NUMBERS', 'false').lower() == 'true'

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,9 +96,10 @@
                 <div id="checkbox-wrapper">
                     <label for="separator">Separator:</label>
                     <select id="separator">
-                        <option value="space">Dash</option>
+                        <option value="dash">Dash</option>
                         <option value="number">Random Number</option>
                         <option value="special">Random Special Character</option>
+                        <option value="space">Space</option>
                         <option value="custom">User Defined</option>
                     </select>
                     <input type="text" id="customSeparator" placeholder="Enter custom separator" style="display: none;">

--- a/utils/password_utils.py
+++ b/utils/password_utils.py
@@ -35,11 +35,14 @@ def calculate_entropy(password):
 def get_random_separator(separator_type, user_defined_separator=''):
     if separator_type == "number":
         return str(secrets.choice(string.digits))
+    elif separator_type == "dash":
+        return '-'
     elif separator_type == "special":
         return secrets.choice(config.special_characters)
     elif separator_type == "single_character":
         return user_defined_separator
-    return '-'
+    elif separator_type == "space":
+        return ' '
 
 async def check_password_pwned(password):
     import httpx


### PR DESCRIPTION
**Fixed:**

- **Passphrase separator config wrong** The option "Dash" had value "space" which caused some issues.
- **Added `space` as a its own separator**
  - Please note that if you have used the default config with env variables defined, you need to check the value of `PP_SEPARATOR_TYPE`!
 
 
Fixes #73 

Thank you `u/edgy_dog` from Reddit for reporting this issue!

To use:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -p 5069:5069 jocxfin/pwgen:latest
```

Offline mode:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -e NO_API_CHECK=true -p 5069:5069 jocxfin/pwgen:latest
```

With environmental variables defining settings:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -p 5069:5069 \\
  -e NO_API_CHECK=false \\
  -e PW_LENGTH=12 \\
  -e PW_INCLUDE_UPPERCASE=false \\
  -e PW_INCLUDE_DIGITS=false \\
  -e PW_INCLUDE_SPECIAL=false \\
  -e PW_EXCLUDE_HOMOGLYPHS=true \\
  -e PP_WORD_COUNT=4 \\
  -e PP_CAPITALIZE=false \\
  -e PP_SEPARATOR_TYPE=dash \\
  -e PP_USER_DEFINED_SEPARATOR='' \\
  -e PP_MAX_WORD_LENGTH=12 \\
  -e PP_INCLUDE_NUMBERS=false \\
  -e PP_INCLUDE_SPECIAL_CHARS=false \\
  -e PP_LANGUAGE=en \\
  -e PP_HIDE_LANG=false \\
  -e PP_LANGUAGE_CUSTOM='' \\
  -e MULTI_GEN=true \\
  jocxfin/pwgen:latest
```

Quick and straightforward improvements for a better tool.