### PR TITLE
Fix wrong passphrase separator config

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ PW_INCLUDE_SPECIAL = os.getenv('PW_INCLUDE_SPECIAL', 'true').lower() == 'true'
 PW_EXCLUDE_HOMOGLYPHS = os.getenv('PW_EXCLUDE_HOMOGLYPHS', 'false').lower() == 'true'
 PP_WORD_COUNT = int(os.getenv('PP_WORD_COUNT', '4'))
 PP_CAPITALIZE = os.getenv('PP_CAPITALIZE', 'false').lower() == 'true'
-PP_SEPARATOR_TYPE = os.getenv('PP_SEPARATOR_TYPE', 'space')
+PP_SEPARATOR_TYPE = os.getenv('PP_SEPARATOR_TYPE', 'dash')
 PP_USER_DEFINED_SEPARATOR = os.getenv('PP_USER_DEFINED_SEPARATOR', '')
 PP_MAX_WORD_LENGTH = int(os.getenv('PP_MAX_WORD_LENGTH', '7'))
 PP_INCLUDE_NUMBERS = os.getenv('PP_INCLUDE_NUMBERS', 'false').lower() == 'true'

--- a/static/index.js
+++ b/static/index.js
@@ -178,5 +178,3 @@ function copyPassword(index) {
         document.body.removeChild(textArea);
     }
 }
-
-generatePassword();

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,21 +27,21 @@
             <div id="checkbox-wrapper">
                 <p>Include Uppercase Letters</p>
                 <div class="checkbox-kaare">
-                    <input class='tgl toggle-omena' type="checkbox" id="includeUppercase" checked>
+                    <input class='tgl toggle-omena' type="checkbox" id="includeUppercase">
                     <label class='tgl-btn' for="includeUppercase"></label>
                 </div>
             </div>
             <div id="checkbox-wrapper">
                 <p>Include Digits</p>
                 <div class="checkbox-kaare">
-                    <input class='tgl toggle-omena' type="checkbox" id="includeDigits" checked>
+                    <input class='tgl toggle-omena' type="checkbox" id="includeDigits">
                     <label class='tgl-btn' for="includeDigits"></label>
                 </div>
             </div>
             <div id="checkbox-wrapper">
                 <p>Include Special Characters</p>
                 <div class="checkbox-kaare">
-                    <input class='tgl toggle-omena' type="checkbox" id="includeSpecial" checked>
+                    <input class='tgl toggle-omena' type="checkbox" id="includeSpecial">
                     <label class='tgl-btn' for="includeSpecial"></label>
                 </div>
             </div>
@@ -53,8 +53,8 @@
                 </div>
             </div>
             <div id="sliderContainer">
-                <label for="lengthSlider">Length: <span id="lengthValue">12</span></label>
-                <input type="range" id="lengthSlider" name="length" min="1" max="69" value="12">
+                <label for="lengthSlider">Length: <span id="lengthValue"></span></label>
+                <input type="range" id="lengthSlider" name="length" min="1" max="69" value="">
             </div>
         </div>
         <div id="passphraseOptions" style="display: none;">
@@ -108,7 +108,7 @@
                     <select id="maxWordLength">
                         <option value="3">3</option>
                         <option value="5">5</option>
-                        <option selected value="5">6</option>
+                        <option value="5">6</option>
                         <option value="7">7</option>
                         <option value="9">9</option>
                         <option value="12">12</option>
@@ -116,8 +116,8 @@
                     </select>
                 </div>
                 <div id="wordCountContainer">
-                    <label for="wordCountSlider">Word Count: <span id="wordCountValue">4</span></label>
-                    <input type="range" id="wordCountSlider" name="wordCount" min="2" max="10" value="4">
+                    <label for="wordCountSlider">Word Count: <span id="wordCountValue"></span></label>
+                    <input type="range" id="wordCountSlider" name="wordCount" min="2" max="10" value="">
                 </div>
             </div>
             <div id="passphrase-wrapper">
@@ -180,14 +180,14 @@
             document.getElementById('includeSpecial').checked = {{ pw_settings.include_special | tojson }};
             document.getElementById('excludeHomoglyphs').checked = {{ pw_settings.exclude_homoglyphs | tojson }};
             document.getElementById('lengthValue').innerText = {{ pw_settings.length }};
-
+            
             document.getElementById('wordCountSlider').value = {{ pp_settings.word_count }};
             document.getElementById('capitalizeWords').checked = {{ pp_settings.capitalize | tojson }};
             document.getElementById('includeNumbers').checked = {{ pp_settings.include_numbers | tojson }};
             document.getElementById('includeSpecialChars').checked = {{ pp_settings.include_special_chars | tojson }};
             document.getElementById('languageSelect').value = "{{ pp_settings.language }}";
             document.getElementById('wordCountValue').innerText = {{ pp_settings.word_count }};
-
+            
             document.getElementById('maxWordLength').value = {{ pp_settings.max_word_length }};
             const separatorValue = "{{ pp_settings.separator_type }}";
             document.getElementById('separator').value = separatorValue;
@@ -196,13 +196,13 @@
                 document.getElementById('customSeparator').value = "{{ pp_settings.user_defined_separator }}";
             }
             const LanguageValue = "{{ pp_settings.language }}";
-            document.getElementById('languageSelect').value = LanguageValue;
             if (LanguageValue === 'custom') {
                 document.getElementById('customLanguage').style.display = 'block';
             }
-            languageSelect.onchange = function () {
+            document.getElementById('languageSelect').onchange = function () {
                 document.getElementById('customLanguage').style.display = this.value === 'custom' ? 'block' : 'none';
             };
+            generatePassword();
         });
     </script>
     <script src="{{ url_for('static', filename='index.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,9 +96,10 @@
                 <div id="checkbox-wrapper">
                     <label for="separator">Separator:</label>
                     <select id="separator">
-                        <option value="space">Dash</option>
+                        <option value="dash">Dash</option>
                         <option value="number">Random Number</option>
                         <option value="special">Random Special Character</option>
+                        <option value="space">Space</option>
                         <option value="custom">User Defined</option>
                     </select>
                     <input type="text" id="customSeparator" placeholder="Enter custom separator" style="display: none;">

--- a/utils/password_utils.py
+++ b/utils/password_utils.py
@@ -66,7 +66,7 @@ async def check_password_pwned(password):
         logging.error(f"Error checking password against HIBP API: {e}")
         return False
 
-async def generate_passphrase(word_count=4, capitalize=False, separator_type='space', max_word_length=12, user_defined_separator='', include_numbers=False, include_special_chars=False, language='en', custom_word_list=None):
+async def generate_passphrase(word_count=config.PP_WORD_COUNT, capitalize=config.PP_CAPITALIZE, separator_type=config.PP_SEPARATOR_TYPE, max_word_length=config.PP_MAX_WORD_LENGTH, user_defined_separator=config.PP_USER_DEFINED_SEPARATOR, include_numbers=config.PP_INCLUDE_NUMBERS, include_special_chars=config.PP_INCLUDE_SPECIAL_CHARS, language=config.PP_LANGUAGE, custom_word_list=config.PP_LANGUAGE_CUSTOM):
     if language == 'custom' and custom_word_list is not None:
         word_list = custom_word_list
     elif language == 'en':

--- a/utils/password_utils.py
+++ b/utils/password_utils.py
@@ -35,11 +35,14 @@ def calculate_entropy(password):
 def get_random_separator(separator_type, user_defined_separator=''):
     if separator_type == "number":
         return str(secrets.choice(string.digits))
+    elif separator_type == "dash":
+        return '-'
     elif separator_type == "special":
         return secrets.choice(config.special_characters)
     elif separator_type == "single_character":
         return user_defined_separator
-    return '-'
+    elif separator_type == "space":
+        return ' '
 
 async def check_password_pwned(password):
     import httpx


### PR DESCRIPTION
**Fixed:**

- **Passphrase separator config wrong** The option "Dash" had value "space" which caused some issues.
- **Added `space` as a its own separator**
  - Please note that if you have used the default config with env variables defined, you need to check the value of `PP_SEPARATOR_TYPE`!
 
 
Fixes #73 

Thank you `u/edgy_dog` from Reddit for reporting this issue!

To use:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -p 5069:5069 jocxfin/pwgen:latest
```

Offline mode:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -e NO_API_CHECK=true -p 5069:5069 jocxfin/pwgen:latest
```

With environmental variables defining settings:

```bash
docker pull jocxfin/pwgen:latest
docker run -d -p 5069:5069 \\
  -e NO_API_CHECK=false \\
  -e PW_LENGTH=12 \\
  -e PW_INCLUDE_UPPERCASE=false \\
  -e PW_INCLUDE_DIGITS=false \\
  -e PW_INCLUDE_SPECIAL=false \\
  -e PW_EXCLUDE_HOMOGLYPHS=true \\
  -e PP_WORD_COUNT=4 \\
  -e PP_CAPITALIZE=false \\
  -e PP_SEPARATOR_TYPE=dash \\
  -e PP_USER_DEFINED_SEPARATOR='' \\
  -e PP_MAX_WORD_LENGTH=12 \\
  -e PP_INCLUDE_NUMBERS=false \\
  -e PP_INCLUDE_SPECIAL_CHARS=false \\
  -e PP_LANGUAGE=en \\
  -e PP_HIDE_LANG=false \\
  -e PP_LANGUAGE_CUSTOM='' \\
  -e MULTI_GEN=true \\
  jocxfin/pwgen:latest
```

Quick and straightforward improvements for a better tool.